### PR TITLE
Add editable title and usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,18 @@
 <body class="bg-gray-100 min-h-screen flex flex-col items-center pt-10 px-4">
 
     <header class="mb-8 text-center w-full">
-        <h1 class="text-3xl sm:text-4xl font-bold text-gray-800">myShortCuts</h1>
-        <p class="text-gray-600 mt-2 text-sm sm:text-base">お気に入りのサイトを登録・編集・並び替えて、素早くアクセス！</p>
+        <h1 class="text-3xl sm:text-4xl font-bold text-gray-800 flex items-center justify-center gap-2">
+            <span id="pageTitleDisplay">myShortCuts</span>
+            <button id="editTitleBtn" class="text-gray-500 hover:text-gray-700" title="タイトルを編集">
+                <i class="fas fa-pencil-alt"></i>
+            </button>
+        </h1>
+        <p class="text-gray-600 mt-2 text-sm sm:text-base flex items-center justify-center gap-2">
+            <span id="usageTextDisplay">お気に入りのサイトを登録・編集・並び替えて、素早くアクセス！</span>
+            <button id="editUsageBtn" class="text-gray-500 hover:text-gray-700" title="使い方を編集">
+                <i class="fas fa-pencil-alt"></i>
+            </button>
+        </p>
     </header>
 
     <div class="flex flex-wrap justify-center gap-3 mb-8">

--- a/script.js
+++ b/script.js
@@ -24,6 +24,14 @@ const importFileElement = document.getElementById('importFile');
 const toastElement = document.getElementById('toast');
 const sortByClicksBtn = document.getElementById('sortByClicksBtn');
 
+// タイトル・使い方関連
+const pageTitleDisplay = document.getElementById('pageTitleDisplay');
+const usageTextDisplay = document.getElementById('usageTextDisplay');
+const editTitleBtn = document.getElementById('editTitleBtn');
+const editUsageBtn = document.getElementById('editUsageBtn');
+const DEFAULT_TITLE = 'myShortCuts';
+const DEFAULT_USAGE = 'お気に入りのサイトを登録・編集・並び替えて、素早くアクセス！';
+
 document.getElementById('currentYear').textContent = new Date().getFullYear();
 let draggedItem = null;
 
@@ -34,6 +42,36 @@ function showToast(message, duration = 3000) {
         toastElement.classList.remove('show');
     }, duration);
 }
+
+// --- タイトル・使い方処理 ---
+function loadTitleAndUsage() {
+    const storedTitle = localStorage.getItem('pageTitle') || DEFAULT_TITLE;
+    const storedUsage = localStorage.getItem('usageText') || DEFAULT_USAGE;
+    pageTitleDisplay.textContent = storedTitle;
+    usageTextDisplay.textContent = storedUsage;
+    document.title = storedTitle;
+}
+
+editTitleBtn.addEventListener('click', () => {
+    const current = pageTitleDisplay.textContent;
+    const newTitle = prompt('タイトルを入力してください', current);
+    if (newTitle !== null) {
+        const finalTitle = newTitle.trim() || DEFAULT_TITLE;
+        pageTitleDisplay.textContent = finalTitle;
+        document.title = finalTitle;
+        localStorage.setItem('pageTitle', finalTitle);
+    }
+});
+
+editUsageBtn.addEventListener('click', () => {
+    const current = usageTextDisplay.textContent;
+    const newUsage = prompt('使い方を入力してください', current);
+    if (newUsage !== null) {
+        const finalUsage = newUsage.trim() || DEFAULT_USAGE;
+        usageTextDisplay.textContent = finalUsage;
+        localStorage.setItem('usageText', finalUsage);
+    }
+});
 
 // --- 追加モーダル処理 ---
 openAddModalBtn.onclick = () => {
@@ -497,4 +535,5 @@ importFileElement.addEventListener('change', (event) => {
     }
 });
 
+loadTitleAndUsage();
 renderShortcuts();


### PR DESCRIPTION
## Summary
- allow editing of site title and usage text
- save changes in localStorage
- load saved values on startup

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_684a772890a8832186040a0f3dca6379